### PR TITLE
v0.2.0: Add CLI arg `size`; copy non-supported files now; ...

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,18 +7,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-## [0.2.0] - 
+## [0.2.0] - 2024-01-20
 
 ### Added
 
 - Optional argument for minimum file size for which a user would like to perform file size reduction.
   - It comes in three sizes: S, M, L, for 100 kB, 500 kB and 1 MB, respectively.
-- Add some info messages: at startup, for copying and for skipping files.
+- Add some info messages: at startup, then for copying and for skipping files.
 
 ### Changed
 
 - When source and destination folders are different, non-supported files will simply be copied to the destination.
   - Previously, they would be left out.
+- Updated `README.md` with Examples and some new Notes.
 
 ## [0.1.0] - 2023-12-29
 This is the very first (initial) fully-functioning version of the program.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Optional argument for minimum file size for which a user would like to perform file size reduction.
   - It comes in three sizes: S, M, L, for 100 kB, 500 kB and 1 MB, respectively.
+- Add some info messages: at startup, for copying and for skipping files.
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,8 +7,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.2.0] - 
+
+### Added
+
 - Optional argument for minimum file size for which a user would like to perform file size reduction.
-  - It can come in three sizes: S, M, L, for 100 kB, 500 kB and 1 MB, respectively.
+  - It comes in three sizes: S, M, L, for 100 kB, 500 kB and 1 MB, respectively.
+
+### Changed
+
+- When source and destination folders are different, non-supported files will simply be copied to the destination.
+  - Previously, they would be left out.
 
 ## [0.1.0] - 2023-12-29
 This is the very first (initial) fully-functioning version of the program.

--- a/README.md
+++ b/README.md
@@ -4,15 +4,17 @@
 Reduces size of images in a folder (and optionally sub-folders, recursively).
 
 This is useful for archiving of photos, for example, as they look the same on a display even with a reduced file size.  
-This application reduces the file sizes of the images in bulk.
+This application reduces file sizes of images in bulk.
 
 By default, keeps the original images and creates copies with reduced file size.
 
 By default, copies the entire folder tree, with all sub-folders that exist in the source tree.  
 The target folder tree will be created automatically, and the new reduced-size images will be copied properly to their respective paths.  
-It is only required to provide the root target folder, and it will also be created if it doesn't exist.
+It is only required to provide the root target folder, and it will also be created if it doesn't exist.  
+Non-supported files will simply be copied to the destination.
 
-The destination folder can be the same as the source folder, in which case the original images will be **overwritten**, and not retained.
+The destination folder can be the same as the source folder, in which case the original images will be **overwritten**, and not retained.  
+Other, non-supported files, will be retained.
 
 If there is enough disk space, it is advised to specify a different destination folder than the source folder,
 so that the original images can be retained and the newly-created reduced-size images can be inspected for quality.  
@@ -24,11 +26,15 @@ If satisfied with the result, original images can be deleted afterwards easily t
 - Look into subdirectories recursively (process the entire tree); recommended: `-r`, `--recursive`
 - Reduce both image dimensions by half: `--resize`
 - JPEG quality, on a scale from 0 (worst) to 95 (best); the default is 75; ignored in case of PNGs: `--quality [QUALITY]`
+- A minimum file size for which a user would like to perform file size reduction: `-s {s,m,l,S,M,L}`, `--size {s,m,l,S,M,L}`
+  - S = 100 kB, M = 500 kB, L = 1 MB
+  - Files that are smaller than the designated size will simply be copied to the destination folder.
 
 ## Notes
 - Developed in Python 3.12.0.
-- Tested on an x86-64 CPU with Windows 11 with JPEGs and PNGs.
-- Might work with other image formats, too, but this hasn't been tested.
+- Tested on an x86-64 CPU on Windows 11.
+- Tested with JPEGs and PNGs.
+- Might work with other image formats, too, but this hasn't been tested. Use at own risk, and work on a copy, as advised above.
 - Other OSes haven't been tested, but should work.
 
 ## Running the Application

--- a/README.md
+++ b/README.md
@@ -30,6 +30,17 @@ If satisfied with the result, original images can be deleted afterwards easily t
   - S = 100 kB, M = 500 kB, L = 1 MB
   - Files that are smaller than the designated size will simply be copied to the destination folder.
 
+### Examples
+See below for how to prepare the application for running.  
+The file paths in the examples are for Windows.
+- `python src\reduce.py D:\img_src D:\img_dst`
+- `python src\reduce.py D:\img_src D:\img_dst -r`
+- `python src\reduce.py D:\img_src D:\img_dst -r -s m`
+- `python src\reduce.py D:\img_src D:\img_dst --recursive --size L`
+- `python src\reduce.py D:\img_src D:\img_dst -r --resize -q 60 -s l`
+- `python src\reduce.py D:\img_src D:\img_dst --recursive --resize --quality 60 --size L`
+
+
 ## Notes
 - Developed in Python 3.12.0.
 - Tested on an x86-64 CPU on Windows 11.

--- a/src/constants.py
+++ b/src/constants.py
@@ -1,0 +1,18 @@
+from enum import IntEnum
+
+QUALITY = 75
+"""JPEG quality default value"""
+
+
+class Size(IntEnum):
+    """ A minimum file size for which to perform file size reduction.
+
+        - DEFAULT = 0
+        - S = 100 kB
+        - M = 500 kB
+        - L = 1 MB
+    """
+    DEFAULT = 0
+    S = 102400
+    M = 512000
+    L = 1048576

--- a/src/reduce.py
+++ b/src/reduce.py
@@ -128,22 +128,18 @@ def main() -> None:
     recursive: bool = args.recursive
     resize: bool = args.resize
     quality: int = args.quality
-    # size_arg: str = args.size[0].lower() if args.size is not None else ""
 
-    # print(args.size, size_arg)###
+    match args.size:
+        case ["s"] | ["S"]: size = Size.S
+        case ["m"] | ["M"]: size = Size.M
+        case ["l"] | ["L"]: size = Size.L
+        case _: size = Size.DEFAULT
 
     try:
         dst_dir.mkdir(parents=True, exist_ok=True)
     except FileExistsError:
         print(f"\"{dst_dir}\" exists and is a file! Provide a proper target directory.")
         return
-
-    # match size_arg:
-    match args.size:
-        case ["s"] | ["S"]: size = Size.S
-        case ["m"] | ["M"]: size = Size.M
-        case ["l"] | ["L"]: size = Size.L
-        case _: size = Size.DEFAULT
 
     print(f"Process recursively: {recursive}")
     print(f"Reduce image dimensions: {resize}")

--- a/src/reduce.py
+++ b/src/reduce.py
@@ -1,62 +1,78 @@
 import argparse
 import datetime
+import shutil
 import timeit
 from pathlib import Path
 
 from PIL import Image
 
-QUALITY = 75
+from constants import QUALITY, Size
 
 
-def different_paths(src_dir: Path, dst_dir: Path, recursive: bool, resize: bool, quality: int) -> None:
+def different_paths(src_dir: Path, dst_dir: Path, recursive: bool, resize: bool, quality: int, size: Size) -> None:
     src_paths = src_dir.glob("*") if not recursive else src_dir.glob("**/*")
 
     for src_path in src_paths:
         if src_path.is_file():
-            try:
-                with Image.open(src_path) as image:
-                    if resize:
-                        image_size = image.size
-                        # Downsize the image with the LANCZOS filter (gives the highest quality).
-                        new_size = (image_size[0] // 2, image_size[1] // 2)
-                        image = image.resize(new_size, Image.Resampling.LANCZOS)
+            # This `mkdir` shouldn't be able to raise (at least not in Python <= 3.12.0),
+            # and the same goes for `relative_to` in this case, so they are not wrapped in try-except.
+            dst_path: Path = dst_dir / src_path.relative_to(src_dir)
+            dst_path.parent.mkdir(parents=True, exist_ok=True)
 
-                    dst_path: Path = dst_dir / src_path.relative_to(src_dir)
-                    dst_path.parent.mkdir(parents=True, exist_ok=True)
+            if src_path.stat().st_size >= size:
+                try:
+                    # We could add the `formats` argument to restrict the set of formats checked,
+                    # but we don't want to restrict it.
+                    with Image.open(src_path) as image:
+                        if resize:
+                            image_size = image.size
+                            # Downsize the image with the LANCZOS filter (gives the highest quality).
+                            new_size = (image_size[0] // 2, image_size[1] // 2)
+                            image = image.resize(new_size, Image.Resampling.LANCZOS)
 
-                    # The argument `optimize` is used for both JPEGs and PNGs.
-                    # The argument `quality` is used for JPEGs, and simply ignored in case of PNGs.
-                    image.save(dst_path, optimize=True, quality=quality)
-                    print(f"Reduced \"{src_path}\" to \"{dst_path}\".", flush=True)
-            except Exception as e:
-                print(e)
+                        # The argument `optimize` is used for both JPEGs and PNGs.
+                        # The argument `quality` is used for JPEGs, and simply ignored in case of PNGs.
+                        image.save(dst_path, optimize=True, quality=quality)
+                        print(f"Reduced \"{src_path}\" to \"{dst_path}\".", flush=True)
+                except Exception as e:
+                    print(e)
+                    # Whatever the reason for failure may be, let's just copy the file to the destination.
+                    # Perhaps it wasn't an image file to begin with, so PIL was not able to process it.
+                    shutil.copy2(src_path, dst_path)
+                    print(f"Copied \"{src_path}\" to \"{dst_path}\".", flush=True)
+            else:
+                # Simply copy the file, whether it's an image or not.
+                shutil.copy2(src_path, dst_path)
+                print(f"Copied \"{src_path}\" to \"{dst_path}\".", flush=True)
 
 
-def same_paths(src_dir: Path, recursive: bool, resize: bool, quality: int) -> None:
+def same_paths(src_dir: Path, recursive: bool, resize: bool, quality: int, size: Size) -> None:
     src_paths = src_dir.glob("*") if not recursive else src_dir.glob("**/*")
 
     for src_path in src_paths:
         if src_path.is_file():
-            try:
-                with Image.open(src_path) as image:
-                    if resize:
-                        image_size = image.size
-                        new_size = (image_size[0] // 2, image_size[1] // 2)
-                        image = image.resize(new_size, Image.Resampling.LANCZOS)
+            if src_path.stat().st_size >= size:
+                try:
+                    with Image.open(src_path) as image:
+                        if resize:
+                            image_size = image.size
+                            new_size = (image_size[0] // 2, image_size[1] // 2)
+                            image = image.resize(new_size, Image.Resampling.LANCZOS)
 
-                    image.save(src_path, optimize=True, quality=quality)
-                    print(f"Reduced \"{src_path}\".", flush=True)
-            except Exception as e:
-                print(e)
+                        image.save(src_path, optimize=True, quality=quality)
+                        print(f"Reduced \"{src_path}\".", flush=True)
+                except Exception as e:
+                    print(e)
+                    print(f"Skipped \"{src_path}\".", flush=True)
+            else:
+                print(f"Skipped \"{src_path}\".", flush=True)
 
 
-def process_images(src_dir: Path, dst_dir: Path, recursive: bool, resize: bool, quality: int) -> None:
-    print(f"JPEG quality = {quality}\n", flush=True)
-
+def process_images(src_dir: Path, dst_dir: Path, recursive: bool, resize: bool, quality: int, size: Size) -> None:
     if src_dir != dst_dir:
-        different_paths(src_dir, dst_dir, recursive, resize, quality)
+        different_paths(src_dir, dst_dir, recursive, resize, quality, size)
     else:
-        same_paths(src_dir, recursive, resize, quality)
+        same_paths(src_dir, recursive, resize, quality, size)
 
 
 def main() -> None:
@@ -97,6 +113,14 @@ def main() -> None:
         help=f"JPEG quality, on a scale from 0 (worst) to 95 (best); "
              f"the default is {QUALITY}; ignored in case of PNGs"
     )
+    parser.add_argument(
+        "-s", "--size",
+        type=str,
+        nargs=1,
+        choices=["s", "m", "l", "S", "M", "L"],
+        help="A minimum file size for which to perform file size reduction; "
+             "S = 100 kB, M = 500 kB, L = 1 MB"
+    )
 
     args = parser.parse_args()
     src_dir: Path = Path(args.src_dir)
@@ -104,6 +128,9 @@ def main() -> None:
     recursive: bool = args.recursive
     resize: bool = args.resize
     quality: int = args.quality
+    # size_arg: str = args.size[0].lower() if args.size is not None else ""
+
+    # print(args.size, size_arg)###
 
     try:
         dst_dir.mkdir(parents=True, exist_ok=True)
@@ -111,7 +138,19 @@ def main() -> None:
         print(f"\"{dst_dir}\" exists and is a file! Provide a proper target directory.")
         return
 
-    process_images(src_dir, dst_dir, recursive, resize, quality)
+    # match size_arg:
+    match args.size:
+        case ["s"] | ["S"]: size = Size.S
+        case ["m"] | ["M"]: size = Size.M
+        case ["l"] | ["L"]: size = Size.L
+        case _: size = Size.DEFAULT
+
+    print(f"Process recursively: {recursive}")
+    print(f"Reduce image dimensions: {resize}")
+    print(f"Minimum image file size for processing is {size} bytes.")
+    print(f"JPEG quality = {quality}\n", flush=True)
+
+    process_images(src_dir, dst_dir, recursive, resize, quality, size)
 
     end = timeit.default_timer()
     diff = end - start

--- a/src/reduce.py
+++ b/src/reduce.py
@@ -2,6 +2,7 @@ import argparse
 import datetime
 import shutil
 import timeit
+from dataclasses import dataclass
 from pathlib import Path
 
 from PIL import Image
@@ -9,7 +10,24 @@ from PIL import Image
 from constants import QUALITY, Size
 
 
-def different_paths(src_dir: Path, dst_dir: Path, recursive: bool, resize: bool, quality: int, size: Size) -> None:
+@dataclass
+class CLIArgs:
+    src_dir: Path
+    dst_dir: Path
+    recursive: bool
+    resize: bool
+    quality: int
+    size: Size
+
+
+def different_paths(cli_args: CLIArgs) -> None:
+    src_dir = cli_args.src_dir
+    dst_dir = cli_args.dst_dir
+    recursive = cli_args.recursive
+    resize = cli_args.resize
+    quality = cli_args.quality
+    size = cli_args.size
+
     src_paths = src_dir.glob("*") if not recursive else src_dir.glob("**/*")
 
     for src_path in src_paths:
@@ -46,7 +64,13 @@ def different_paths(src_dir: Path, dst_dir: Path, recursive: bool, resize: bool,
                 print(f"Copied \"{src_path}\" to \"{dst_path}\".", flush=True)
 
 
-def same_paths(src_dir: Path, recursive: bool, resize: bool, quality: int, size: Size) -> None:
+def same_paths(cli_args: CLIArgs) -> None:
+    src_dir = cli_args.src_dir
+    recursive = cli_args.recursive
+    resize = cli_args.resize
+    quality = cli_args.quality
+    size = cli_args.size
+
     src_paths = src_dir.glob("*") if not recursive else src_dir.glob("**/*")
 
     for src_path in src_paths:
@@ -68,11 +92,11 @@ def same_paths(src_dir: Path, recursive: bool, resize: bool, quality: int, size:
                 print(f"Skipped \"{src_path}\".", flush=True)
 
 
-def process_images(src_dir: Path, dst_dir: Path, recursive: bool, resize: bool, quality: int, size: Size) -> None:
-    if src_dir != dst_dir:
-        different_paths(src_dir, dst_dir, recursive, resize, quality, size)
+def process_images(cli_args: CLIArgs) -> None:
+    if cli_args.src_dir != cli_args.dst_dir:
+        different_paths(cli_args)
     else:
-        same_paths(src_dir, recursive, resize, quality, size)
+        same_paths(cli_args)
 
 
 def main() -> None:
@@ -135,6 +159,8 @@ def main() -> None:
         case ["l"] | ["L"]: size = Size.L
         case _: size = Size.DEFAULT
 
+    cli_args = CLIArgs(src_dir, dst_dir, recursive, resize, quality, size)
+
     try:
         dst_dir.mkdir(parents=True, exist_ok=True)
     except FileExistsError:
@@ -146,7 +172,7 @@ def main() -> None:
     print(f"Minimum image file size for processing is {size} bytes.")
     print(f"JPEG quality = {quality}\n", flush=True)
 
-    process_images(src_dir, dst_dir, recursive, resize, quality, size)
+    process_images(cli_args)
 
     end = timeit.default_timer()
     diff = end - start


### PR DESCRIPTION
Add CLI arg `size`; copy non-supported files now; add constants.py; add info output at startup

## [0.2.0] - 2024-01-20

### Added

- Optional argument for minimum file size for which a user would like to perform file size reduction.
  - It comes in three sizes: S, M, L, for 100 kB, 500 kB and 1 MB, respectively.
- Add some info messages: at startup, then for copying and for skipping files.

### Changed

- When source and destination folders are different, non-supported files will simply be copied to the destination.
  - Previously, they would be left out.
- Updated `README.md` with Examples and some new Notes.